### PR TITLE
migrating away from deprecated npm dependency to nodejs dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,32 @@
+{
+  "name": "forever",
+  "description": "Chef cookbook for running node apps using forever.",
+  "long_description": "See README.md",
+  "maintainer": "David Radcliffe",
+  "maintainer_email": "david@trabian.com",
+  "license": "MIT",
+  "platforms": {
+    "redhat": ">= 0.0.0",
+    "centos": ">= 0.0.0"
+  },
+  "dependencies": {
+    "nodejs": "latest"
+  },
+  "recommendations": {
+  },
+  "suggestions": {
+  },
+  "conflicting": {
+  },
+  "providing": {
+  },
+  "replacing": {
+  },
+  "attributes": {
+  },
+  "groupings": {
+  },
+  "recipes": {
+  },
+  "version": "0.1.2"
+}

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,9 +4,9 @@ maintainer_email "david@trabian.com"
 license          "MIT"
 description      "Chef cookbook for running node apps using forever."
 long_description "See README.md"
-version          "0.1.1"
+version          "0.1.2"
 
 supports "redhat"
 supports "centos"
 
-depends "npm"
+depends "nodejs"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,1 +1,1 @@
-npm_package "forever"
+nodejs_npm "forever"


### PR DESCRIPTION
Hello,

First, thanks for creating this cookbook, very useful!

I'm leveraging this cookbook from the supermarket and ran into some errors when trying to upload it to my chef server:

`Cookbook forever version 0.1.1 successfully installed
Installing npm to /chef-repo/cookbooks
Checking out the master branch.
Creating pristine copy branch chef-vendor-cpm
WARNING: DEPRECATION: This cookbook has been deprecated. It has been replaced by nodejs.
WARNING: Use --force to force download deprecated cookbook.
Removing pre-existing version.
Uncompressing npm version 0.1.2.
ERROR: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'`

The fix seemed to be to update the code to leverage nodejs instead of npm which had been deprecated.

I've:
- Updated the code to use `nodejs_npm` instead of `npm_package` in default.rb
- Updated the version number to 0.1.2
- Updated the dependency in metatdata.rb
- Added the metadata.json which existed in the supermarket version: https://supermarket.getchef.com/cookbooks/forever
